### PR TITLE
Use single quotes to avoid shell expansion at time of definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Typing the above commands is not really convenient. With a simple alias you can
 simplify the executed commands:
 
 ``` bash
-alias doc="docker run --rm --tty --interactive --volume $PWD:/doc --user $(id -u):$(id -g) webplates/readthedocs"
+alias doc='docker run --rm --tty --interactive --volume `pwd`:/doc --user $(id -u):$(id -g) webplates/readthedocs'
 ```
 
 (Put this in your shell startup script: `~/.bashrc`, `~/.zshrc`, etc)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Typing the above commands is not really convenient. With a simple alias you can
 simplify the executed commands:
 
 ``` bash
-alias doc='docker run --rm --tty --interactive --volume `pwd`:/doc --user $(id -u):$(id -g) webplates/readthedocs'
+alias doc='docker run --rm --tty --interactive --volume $PWD:/doc --user $(id -u):$(id -g) webplates/readthedocs'
 ```
 
 (Put this in your shell startup script: `~/.bashrc`, `~/.zshrc`, etc)


### PR DESCRIPTION
The `$PWD` was always translated to my home dir. This PR fixes that issue. 